### PR TITLE
 Allow bummr update to be run in headless mode

### DIFF
--- a/lib/bummr.rb
+++ b/lib/bummr.rb
@@ -1,5 +1,6 @@
 # grouped by dependency order than alpha
 require 'bummr/log'
+require "bummr/scm"
 require 'rainbow/ext/string'
 require 'open3'
 require 'singleton'

--- a/lib/bummr.rb
+++ b/lib/bummr.rb
@@ -7,6 +7,7 @@ require 'thor'
 
 require "bummr/bisecter"
 require "bummr/check"
+require "bummr/git"
 require "bummr/outdated"
 require "bummr/rebaser"
 require "bummr/updater"

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -4,6 +4,7 @@ BASE_BRANCH = ENV["BASE_BRANCH"] || "master"
 module Bummr
   class CLI < Thor
     include Bummr::Log
+    include Bummr::Scm
 
     desc "check", "Run automated checks to see if bummr can be run"
     def check(fullcheck=true)
@@ -30,7 +31,7 @@ module Bummr
         else
           Bummr::Updater.new(outdated_gems).update_gems
 
-          system("git rebase -i #{BASE_BRANCH}")
+          git.rebase_interactive(BASE_BRANCH)
           test
         end
       else

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -16,6 +16,10 @@ module Bummr
       system("#{git_commit} -m '#{message}'")
     end
 
+    def message(sha)
+      `git log --pretty=format:'%s' -n 1 #{sha}`
+    end
+
     private
 
     attr_reader :git_commit

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -12,6 +12,7 @@ module Bummr
     end
 
     def commit(message)
+      log "Commit: #{message}".color(:green)
       system("#{git_commit} -m '#{message}'")
     end
 

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -1,0 +1,18 @@
+module Bummr
+  class Git
+    include Singleton
+    include Log
+
+    def initialize
+      @git_commit = ENV.fetch("BUMMR_GIT_COMMIT") { "git commit" }
+    end
+
+    def commit(message)
+      system("#{git_commit} -am '#{message}'")
+    end
+
+    private
+
+    attr_reader :git_commit
+  end
+end

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -16,6 +16,10 @@ module Bummr
       system("#{git_commit} -m '#{message}'")
     end
 
+    def rebase_interactive(sha)
+      system("git rebase -i #{BASE_BRANCH}")
+    end
+
     def message(sha)
       `git log --pretty=format:'%s' -n 1 #{sha}`
     end

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -7,8 +7,12 @@ module Bummr
       @git_commit = ENV.fetch("BUMMR_GIT_COMMIT") { "git commit" }
     end
 
+    def add(files)
+      system("git add #{files}")
+    end
+
     def commit(message)
-      system("#{git_commit} -am '#{message}'")
+      system("#{git_commit} -m '#{message}'")
     end
 
     private

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -20,6 +20,10 @@ module Bummr
       system("git rebase -i #{BASE_BRANCH}")
     end
 
+    def rebase(sha)
+      system("git rebase #{BASE_BRANCH}")
+    end
+
     def message(sha)
       `git log --pretty=format:'%s' -n 1 #{sha}`
     end

--- a/lib/bummr/rebaser.rb
+++ b/lib/bummr/rebaser.rb
@@ -2,6 +2,7 @@ module Bummr
   class Rebaser
     include Singleton
     include Log
+    include Scm
 
     def remove_commit(sha)
       log "Bad commit: #{commit_message_for(sha)}, #{sha}".color(:red)

--- a/lib/bummr/rebaser.rb
+++ b/lib/bummr/rebaser.rb
@@ -5,7 +5,7 @@ module Bummr
     include Scm
 
     def remove_commit(sha)
-      log "Bad commit: #{commit_message_for(sha)}, #{sha}".color(:red)
+      log "Bad commit: #{git.message(sha)}, #{sha}".color(:red)
       log "Resetting..."
       system("git bisect reset")
 
@@ -19,12 +19,6 @@ module Bummr
         log "Please resolve conflicts, then 'git rebase --continue'."
         log "Run 'bummr test' again once the rebase is complete"
       end
-    end
-
-    private
-
-    def commit_message_for(sha)
-      `git log --pretty=format:'%s' -n 1 #{sha}`
     end
   end
 end

--- a/lib/bummr/scm.rb
+++ b/lib/bummr/scm.rb
@@ -1,0 +1,9 @@
+module Bummr
+  module Scm
+    private
+
+    def git
+      Bummr::Git.instance
+    end
+  end
+end

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -31,6 +31,7 @@ module Bummr
         log("#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}")
       end
 
+      git.add("Gemfile Gemfile.lock")
       git.commit(message)
     end
 

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -31,7 +31,6 @@ module Bummr
         log("#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}")
       end
 
-      log "Commit: #{message}".color(:green)
       git.commit(message)
     end
 

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -4,6 +4,7 @@ module Bummr
 
     def initialize(outdated_gems)
       @outdated_gems = outdated_gems
+      @git = Bummr::Git.instance
     end
 
     def update_gems
@@ -31,12 +32,16 @@ module Bummr
       end
 
       log "Commit: #{message}".color(:green)
-      system("git commit -am '#{message}'")
+      git.commit(message)
     end
 
     def updated_version_for(gem)
       `bundle list | grep " #{gem[:name]} "`.split('(')[1].split(')')[0]
     end
+
+    private
+
+    attr_reader :git
   end
 end
 

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -1,10 +1,10 @@
 module Bummr
   class Updater
     include Log
+    include Scm
 
     def initialize(outdated_gems)
       @outdated_gems = outdated_gems
-      @git = Bummr::Git.instance
     end
 
     def update_gems
@@ -38,10 +38,6 @@ module Bummr
     def updated_version_for(gem)
       `bundle list | grep " #{gem[:name]} "`.split('(')[1].split(')')[0]
     end
-
-    private
-
-    attr_reader :git
   end
 end
 

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -16,52 +16,159 @@ describe Bummr::CLI do
   }
 
   describe "#update" do
-    context "when user rejects moving forward" do
-      it "does not attempt to move forward" do
-        expect(cli).to receive(:yes?).and_return(false)
-        expect(cli).not_to receive(:check)
+    context "when run in interactive mode" do
+      context "and user rejects moving forward" do
+        it "does not attempt to move forward" do
+          expect(cli).to receive(:yes?).and_return(false)
+          expect(cli).not_to receive(:check)
 
-        cli.update
-      end
-    end
-
-    context "when user agrees to move forward" do
-      def mock_bummr_standard_flow
-        updater = double
-        allow(updater).to receive(:update_gems)
-
-        expect(cli).to receive(:ask_questions)
-        expect(cli).to receive(:yes?).and_return(true)
-        expect(cli).to receive(:check)
-        expect(cli).to receive(:log)
-        expect(cli).to receive(:system).with("bundle")
-        expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
-        expect(cli).to receive(:test)
-        expect(git).to receive(:rebase_interactive).with(BASE_BRANCH)
+          cli.update
+        end
       end
 
-      context "and there are no outdated gems" do
-        it "informs that there are no outdated gems" do
-          allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
-            .and_return []
+      context "and the user agrees to move forward" do
+        def mock_bummr_standard_flow
+          updater = double
+          allow(updater).to receive(:update_gems)
 
           expect(cli).to receive(:ask_questions)
           expect(cli).to receive(:yes?).and_return(true)
           expect(cli).to receive(:check)
           expect(cli).to receive(:log)
           expect(cli).to receive(:system).with("bundle")
+          expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
+          expect(cli).to receive(:test)
+          expect(git).to receive(:rebase_interactive).with(BASE_BRANCH)
+        end
+
+        context "and there are no outdated gems" do
+          it "informs that there are no outdated gems" do
+            allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
+              .and_return []
+
+            expect(cli).to receive(:ask_questions)
+            expect(cli).to receive(:yes?).and_return(true)
+            expect(cli).to receive(:check)
+            expect(cli).to receive(:log)
+            expect(cli).to receive(:system).with("bundle")
+            expect(cli).to receive(:puts).with("No outdated gems to update".color(:green))
+
+            cli.update
+          end
+        end
+
+        context "and there are outdated gems" do
+          it "calls 'update' on the updater" do
+            allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
+              .and_return outdated_gems
+
+            mock_bummr_standard_flow
+
+            cli.update
+          end
+        end
+
+        describe "all option" do
+          it "requests all outdated gems be listed" do
+            options[:all] = true
+
+            expect_any_instance_of(Bummr::Outdated)
+              .to receive(:outdated_gems).with(hash_including({ all_gems: true }))
+              .and_return outdated_gems
+
+            mock_bummr_standard_flow
+
+            cli.update
+          end
+        end
+
+        describe "group option" do
+          it "requests only outdated gems from supplied be listed" do
+            options[:group] = 'test'
+
+            expect_any_instance_of(Bummr::Outdated)
+              .to receive(:outdated_gems).with(hash_including({ group: 'test' }))
+              .and_return outdated_gems
+
+            mock_bummr_standard_flow
+
+            cli.update
+          end
+        end
+      end
+    end
+
+    context "when run in headless mode" do
+      let(:options) { { headless: true } }
+
+      it "skips interactive functionality" do
+        expect(cli).not_to receive(:ask_questions)
+        expect(cli).not_to receive(:yes?)
+        expect(cli).not_to receive(:check)
+
+        mock_bummr_headless_flow
+
+        cli.update
+      end
+
+      it "logs an intitial message" do
+        expect(cli).to receive(:log)
+
+        mock_bummr_headless_flow
+
+        cli.update
+      end
+
+      it "calls bundle" do
+        expect(cli).to receive(:system).with("bundle")
+
+        mock_bummr_headless_flow
+
+        cli.update
+      end
+
+      context "and there are no outdated gems" do
+        it "informs that there are no outdated gems" do
           expect(cli).to receive(:puts).with("No outdated gems to update".color(:green))
+
+          outdated_instance = stub_outdated(outdated_gems: [])
+          mock_bummr_headless_flow(outdated_instance: outdated_instance)
 
           cli.update
         end
       end
 
       context "and there are outdated gems" do
-        it "calls 'update' on the updater" do
-          allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
-            .and_return outdated_gems
+        it "calls 'update_gems' on the updater" do
+          updater = stub_updater(outdated_gems: outdated_gems)
+          expect(updater).to receive(:update_gems)
 
-          mock_bummr_standard_flow
+          mock_bummr_headless_flow(
+            outdated_instance: stub_outdated(outdated_gems: outdated_gems),
+            updater_instance: updater
+          )
+
+          cli.update
+        end
+
+        it "calls a non-interactive rebase" do
+          expect(git).to receive(:rebase).with(BASE_BRANCH)
+
+          mock_bummr_headless_flow(
+            outdated_instance: stub_outdated(outdated_gems: outdated_gems),
+            updater_instance: stub_updater(outdated_gems: outdated_gems)
+          )
+
+          cli.update
+        end
+
+        it "calls #test" do
+          expect(cli).to receive(:test)
+
+          mock_bummr_headless_flow(
+            outdated_instance: stub_outdated(outdated_gems: outdated_gems),
+            updater_instance: stub_updater(outdated_gems: outdated_gems)
+          )
 
           cli.update
         end
@@ -71,11 +178,15 @@ describe Bummr::CLI do
         it "requests all outdated gems be listed" do
           options[:all] = true
 
-          expect_any_instance_of(Bummr::Outdated)
+          outdated_instance = Bummr::Outdated.instance
+          expect(outdated_instance)
             .to receive(:outdated_gems).with(hash_including({ all_gems: true }))
             .and_return outdated_gems
 
-          mock_bummr_standard_flow
+          mock_bummr_headless_flow(
+            outdated_instance: outdated_instance,
+            updater_instance: stub_updater(outdated_gems: outdated_gems)
+          )
 
           cli.update
         end
@@ -85,14 +196,40 @@ describe Bummr::CLI do
         it "requests only outdated gems from supplied be listed" do
           options[:group] = 'test'
 
-          expect_any_instance_of(Bummr::Outdated)
+          outdated_instance = Bummr::Outdated.instance
+          expect(outdated_instance)
             .to receive(:outdated_gems).with(hash_including({ group: 'test' }))
             .and_return outdated_gems
 
-          mock_bummr_standard_flow
+          mock_bummr_headless_flow(
+            outdated_instance: outdated_instance,
+            updater_instance: stub_updater(outdated_gems: outdated_gems)
+          )
 
           cli.update
         end
+      end
+
+      def mock_bummr_headless_flow(outdated_instance: nil, updater_instance: nil)
+        outdated_instance || stub_outdated(outdated_gems: [])
+        updater_instance || stub_updater(outdated_gems: [])
+
+        allow(cli).to receive(:log)
+        allow(cli).to receive(:system).with("bundle")
+        allow(cli).to receive(:test)
+        allow(git).to receive(:rebase).with(BASE_BRANCH)
+      end
+
+      def stub_outdated(outdated_gems: [])
+        outdated = Bummr::Outdated.instance
+        allow(outdated).to receive(:outdated_gems).and_return outdated_gems
+        outdated
+      end
+
+      def stub_updater(outdated_gems: [])
+        updater = double("Updater", update_gems: nil)
+        allow(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
+        updater
       end
     end
   end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -6,6 +6,7 @@ describe Bummr::CLI do
   let(:options) { {} }
   let(:config) { { pretend: true } }
   let(:cli) { described_class.new(args, options, config) }
+  let(:git) { Bummr::Git.instance }
   let(:outdated_gems) {
     [
       { name: "myGem", installed: "0.3.2", newest: "0.3.5" },
@@ -35,8 +36,8 @@ describe Bummr::CLI do
         expect(cli).to receive(:log)
         expect(cli).to receive(:system).with("bundle")
         expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
-        expect(cli).to receive(:system).with("git rebase -i #{BASE_BRANCH}")
         expect(cli).to receive(:test)
+        expect(git).to receive(:rebase_interactive).with(BASE_BRANCH)
       end
 
       context "and there are no outdated gems" do

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -15,6 +15,17 @@ describe Bummr::Git do
   end
 
   describe "#commit" do
+    it "logs the commit" do
+      git = stub_git
+      commit_message = "Update Foo from 0.0.1 to 0.0.2"
+
+      git.commit(commit_message)
+
+      expect(git).to have_received(:log).with(
+        /Commit: #{commit_message}/
+      )
+    end
+
     it "commits with a message" do
       git = stub_git
       commit_message = "Update Foo from 0.0.1 to 0.0.2"

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -52,10 +52,24 @@ describe Bummr::Git do
     end
   end
 
+  describe "#message" do
+    it "displays the commit message for a given sha" do
+      git = stub_git
+      sha = "b39dcd8"
+
+      git.message(sha)
+
+      expect(git).to have_received(:`).with(
+        "git log --pretty=format:'%s' -n 1 #{sha}"
+      )
+    end
+  end
+
   def stub_git
     git = Bummr::Git.clone.instance
     allow(git).to receive(:log)
     allow(git).to receive(:system)
+    allow(git).to receive(:`)
     git
   end
 end

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -1,6 +1,19 @@
 require "spec_helper"
 
 describe Bummr::Git do
+  describe "#add" do
+    it "stages specified files with git" do
+      git = stub_git
+      files = "Gemfile Gemfile.lock"
+
+      git.add(files)
+
+      expect(git).to have_received(:system).with(
+        "git add #{files}"
+      )
+    end
+  end
+
   describe "#commit" do
     it "commits with a message" do
       git = stub_git
@@ -9,7 +22,7 @@ describe Bummr::Git do
       git.commit(commit_message)
 
       expect(git).to have_received(:system).with(
-        "git commit -am '#{commit_message}'"
+        "git commit -m '#{commit_message}'"
       )
     end
 
@@ -22,7 +35,7 @@ describe Bummr::Git do
         git.commit(commit_message)
 
         expect(git).to have_received(:system).with(
-          "git commit --no-verify -am '#{commit_message}'"
+          "git commit --no-verify -m '#{commit_message}'"
         )
       end
     end

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Bummr::Git do
+  describe "#commit" do
+    it "commits with a message" do
+      git = stub_git
+      commit_message = "Update Foo from 0.0.1 to 0.0.2"
+
+      git.commit(commit_message)
+
+      expect(git).to have_received(:system).with(
+        "git commit -am '#{commit_message}'"
+      )
+    end
+
+    describe "when BUMMR_GIT_COMMIT is defined" do
+      it "commits using defined value" do
+        allow(ENV).to receive(:fetch).with("BUMMR_GIT_COMMIT").and_return("git commit --no-verify")
+        git = stub_git
+        commit_message = "Update Foo from 0.0.1 to 0.0.2"
+
+        git.commit(commit_message)
+
+        expect(git).to have_received(:system).with(
+          "git commit --no-verify -am '#{commit_message}'"
+        )
+      end
+    end
+  end
+
+  def stub_git
+    git = Bummr::Git.clone.instance
+    allow(git).to receive(:log)
+    allow(git).to receive(:system)
+    git
+  end
+end

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -52,6 +52,19 @@ describe Bummr::Git do
     end
   end
 
+  describe "#rebase_interactive" do
+    it "runs git interactive rebase to the given sha" do
+      git = stub_git
+      sha = "b39dcd8"
+
+      git.rebase_interactive(sha)
+
+      expect(git).to have_received(:system).with(
+        "git rebase -i #{BASE_BRANCH}"
+      )
+    end
+  end
+
   describe "#message" do
     it "displays the commit message for a given sha" do
       git = stub_git

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -65,6 +65,19 @@ describe Bummr::Git do
     end
   end
 
+  describe "#rebase" do
+    it "runs git rebase to the given sha" do
+      git = stub_git
+      sha = "b39dcd8"
+
+      git.rebase(sha)
+
+      expect(git).to have_received(:system).with(
+        "git rebase #{BASE_BRANCH}"
+      )
+    end
+  end
+
   describe "#message" do
     it "displays the commit message for a given sha" do
       git = stub_git

--- a/spec/lib/rebaser_spec.rb
+++ b/spec/lib/rebaser_spec.rb
@@ -1,19 +1,20 @@
 require "spec_helper"
 
 describe Bummr::Rebaser do
-  # let(:commit_message) { "test commit message" }
   let(:rebaser) { Bummr::Rebaser.instance }
+  let(:git) { Bummr::Git.instance }
   let(:sha) { "testsha" }
   let(:rebase_command) { "git rebase -X ours --onto #{sha}^ #{sha}" }
 
   before do
-    allow(rebaser).to receive(:commit_message_for).and_return "commit message"
     allow(rebaser).to receive(:log)
     allow(rebaser).to receive(:system)
   end
 
   describe "#remove_commit" do
     it "logs the bad commit" do
+      allow(git).to receive(:message).and_return("commit message")
+
       rebaser.remove_commit(sha)
 
       expect(rebaser).to have_received(:log).with(

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -96,17 +96,6 @@ describe Bummr::Updater do
         allow(updater).to receive(:updated_version_for).and_return newest
       end
 
-      it "logs the commit" do
-        commit_message =
-          "Commit: Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}".color(:green)
-        allow(updater).to receive(:system)
-        allow(updater).to receive(:log)
-
-        updater.update_gem(gem, 0)
-
-        expect(updater).to have_received(:log).with commit_message
-      end
-
       it "commits" do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -14,6 +14,7 @@ describe Bummr::Updater do
   let(:installed) { outdated_gems[0][:installed] }
   let(:intermediate_version) { "0.3.4" }
   let(:update_cmd) { "bundle update #{gem[:name]}" }
+  let(:git) { Bummr::Git.instance }
 
   describe "#update_gems" do
     it "calls update_gem on each gem" do
@@ -51,10 +52,11 @@ describe Bummr::Updater do
         allow(updater).to receive(:system).with(update_cmd)
         allow(updater).to receive(:updated_version_for).with(gem).and_return installed
         allow(updater).to receive(:log)
+        allow(git).to receive(:commit)
 
         updater.update_gem(gem, 0)
 
-        expect(updater).to_not have_received(:system).with /git commit/
+        expect(git).to_not have_received(:commit)
       end
     end
 
@@ -78,15 +80,14 @@ describe Bummr::Updater do
 
       it "commits" do
         commit_message =
-          "'Update #{gem[:name]} from #{gem[:installed]} to #{intermediate_version}'"
+          "Update #{gem[:name]} from #{gem[:installed]} to #{intermediate_version}"
         allow(updater).to receive(:system)
         allow(updater).to receive(:log)
+        allow(git).to receive(:commit)
 
         updater.update_gem(gem, 0)
 
-        expect(updater).to have_received(:system).with(
-          "git commit -am #{commit_message}"
-        )
+        expect(git).to have_received(:commit).with(commit_message)
       end
     end
 
@@ -111,12 +112,11 @@ describe Bummr::Updater do
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"
         allow(updater).to receive(:system)
         allow(updater).to receive(:log)
+        allow(git).to receive(:commit)
 
         updater.update_gem(gem, 0)
 
-        expect(updater).to have_received(:system).with(
-          "git commit -am '#{commit_message}'"
-        )
+        expect(git).to have_received(:commit).with(commit_message)
       end
     end
   end

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -78,15 +78,16 @@ describe Bummr::Updater do
         expect(updater).to have_received(:log).with not_latest_message
       end
 
-      it "commits" do
+      it "commits gem related files" do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{intermediate_version}"
         allow(updater).to receive(:system)
         allow(updater).to receive(:log)
-        allow(git).to receive(:commit)
+        allow(git).to receive_messages([:commit, :add])
 
         updater.update_gem(gem, 0)
 
+        expect(git).to have_received(:add).with("Gemfile Gemfile.lock")
         expect(git).to have_received(:commit).with(commit_message)
       end
     end
@@ -96,15 +97,16 @@ describe Bummr::Updater do
         allow(updater).to receive(:updated_version_for).and_return newest
       end
 
-      it "commits" do
+      it "commits gem related files" do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"
         allow(updater).to receive(:system)
         allow(updater).to receive(:log)
-        allow(git).to receive(:commit)
+        allow(git).to receive_messages([:commit, :add])
 
         updater.update_gem(gem, 0)
 
+        expect(git).to have_received(:add).with("Gemfile Gemfile.lock")
         expect(git).to have_received(:commit).with(commit_message)
       end
     end


### PR DESCRIPTION
- remove any required user interaction
- allows `bummr update` to be run as an automated task (ie, cron, CI, etc)